### PR TITLE
Hiding inactive tasks from the complete tasks list

### DIFF
--- a/src/Moneo.Chat/Moneo.Chat.Tests/UnitTest1.cs
+++ b/src/Moneo.Chat/Moneo.Chat.Tests/UnitTest1.cs
@@ -26,11 +26,7 @@ public class UnitTest1
         
         long conversationId = 1;
         var userString = "/complete";
-        var context = new CommandContext()
-        {
-            ConversationId = 1,
-            CurrentState = ChatState.Waiting
-        };
+        var context = CommandContext.Get(1, ChatState.Waiting, userString);
         
         var parts = userString.Split(' ');
         context.CommandKey = parts[0].ToLowerInvariant();

--- a/src/Moneo.Chat/Moneo.Chat/Workflows/CompleteTask/CompleteTaskRequestHandler.cs
+++ b/src/Moneo.Chat/Moneo.Chat/Workflows/CompleteTask/CompleteTaskRequestHandler.cs
@@ -37,7 +37,7 @@ internal class CompleteTaskRequestHandler : IRequestHandler<CompleteTaskRequest,
             };
         }
 
-        var tasks = tasksMatchingName.Result.ToArray();
+        var tasks = tasksMatchingName.Result.Where(t => t.IsActive).ToArray();
 
         if (tasks.Length == 1)
         {

--- a/src/Moneo.TaskManagement/Moneo.TaskManagement.Client/TaskResourceManager.cs
+++ b/src/Moneo.TaskManagement/Moneo.TaskManagement.Client/TaskResourceManager.cs
@@ -163,6 +163,12 @@ public class TaskResourceManager : ITaskResourceManager
         var matches = FuzzySharp.Process.ExtractTop(filter.SearchString, lookup.Keys, cutoff: 75).ToArray();
         if (matches.Length > 0)
         {
+            var perfectMatch = matches.SingleOrDefault(match => match.Score == 100);
+            if (perfectMatch is not null)
+            {
+                return new MoneoTaskResult<IEnumerable<MoneoTaskDto>>(true, [lookup[perfectMatch.Value]]);
+            }
+            
             return new MoneoTaskResult<IEnumerable<MoneoTaskDto>>(true,
                 lookup
                     .Where(kv => matches.Select(x => x.Value).Contains(kv.Key))


### PR DESCRIPTION
Fixes a previously unknown issue where if two tasks have similar names and one is inactive, the user can get stuck in a loop trying to complete the active task.

This is a first step fix that prevents the bot from asking the user if they meant to complete an inactive task. Will need to come up with a way to handle a situation when the user has two active tasks with similar enough names that the bot can't tell the difference.

Ultimately will need to either enforce name uniqueness across tasks for a given user, or will need to support completing a task by ID - which is complicated by the inability for the user to necessarily differentiate either.