### PR TITLE
Refactored code generation and UserCommand registration

### DIFF
--- a/src/Chat/Moneo.Chat.Generators/Moneo.Chat.Generators.csproj
+++ b/src/Chat/Moneo.Chat.Generators/Moneo.Chat.Generators.csproj
@@ -16,35 +16,4 @@
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
     </ItemGroup>
 
-<!--
-    <ItemGroup>
-        <PackageReference Include="MediatR" Version="12.2.0" GeneratePathProperty="true" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
-    </PropertyGroup>
-
-    <Target Name="GetDependencyTargetPaths">
-        <ItemGroup>
-            <TargetPathWithTargetPlatformMoniker Include="$(PkgMediatr)\lib\netstandard2.0\Mediatr.dll" IncludeRuntimeDependency="false" />
-        </ItemGroup>
-    </Target>
--->
-<!--
-    <PropertyGroup>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
-    </PropertyGroup>
-
-    <Target Name="CleanSourceGeneratedFiles" BeforeTargets="BeforeBuild" DependsOnTargets="$(BeforeBuildDependsOn)">
-        <RemoveDir Directories="Generated" />
-    </Target>
-
-    <ItemGroup>
-        <Compile Remove="Generated\**" />
-        <Content Include="Generated\**" />
-    </ItemGroup>
--->
-
 </Project>

--- a/src/Chat/Moneo.Chat.Tests/UnitTest1.cs
+++ b/src/Chat/Moneo.Chat.Tests/UnitTest1.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Moneo.Chat.CommandRegistration;
 using Moneo.Chat.Commands;
 using Moq;
 using Moneo.Chat.Workflows;
@@ -23,14 +24,15 @@ public class UnitTest1
                     UserMessageText = "Please select a task:",
                     MenuOptions = ["Option 1", "Option 2"]
                 });
+
+        CommandRegistrar.RegisterCommands(new MoneoChatCommandConfiguration
+        {
+            UserRequestsToRegister = { typeof(CompleteTaskRequest) }
+        });
         
         long conversationId = 1;
         var userString = "/complete";
         var context = CommandContext.Get(1, ChatState.Waiting, userString);
-        
-        var parts = userString.Split(' ');
-        context.CommandKey = parts[0].ToLowerInvariant();
-        context.Args = parts[1..];
 
         var request = UserRequestFactory.GetUserRequest(context) as CompleteTaskRequest;
 

--- a/src/Chat/Moneo.Chat/CommandRegistration/ChatCommandConfiguration.cs
+++ b/src/Chat/Moneo.Chat/CommandRegistration/ChatCommandConfiguration.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+
+namespace Moneo.Chat.CommandRegistration;
+
+public class MoneoChatCommandConfiguration
+{
+    internal List<Assembly> ChatCommandAssemblies { get; } = [];
+    internal List<Type> UserRequestsToRegister { get; } = [];
+    
+    public MoneoChatCommandConfiguration RegisterUserRequestsFromAssemblyContaining<T>()
+        => RegisterUserRequestsFromAssemblyContaining(typeof(T));
+
+    public MoneoChatCommandConfiguration RegisterUserRequestsFromAssemblyContaining(Type type)
+        => RegisterUserRequestsFromAssembly(type.Assembly);
+    
+    public MoneoChatCommandConfiguration RegisterUserRequestsFromAssembly(Assembly assembly)
+    {
+        ChatCommandAssemblies.Add(assembly);
+        return this;
+    }
+    
+    public MoneoChatCommandConfiguration RegisterUserRequestsFromAssemblies(params Assembly[] assemblies)
+    {
+        ChatCommandAssemblies.AddRange(assemblies);
+        return this;
+    }
+    
+    public MoneoChatCommandConfiguration RegisterUserRequest(Type userRequest)
+    {
+        if (!typeof(IUserRequest).IsAssignableFrom(userRequest) ||
+            !typeof(UserRequestBase).IsAssignableFrom(userRequest) || 
+            userRequest.IsAbstract)
+        {
+            throw new ArgumentException($"Type {userRequest.Name} is not a valid user request type.");
+        }
+
+        UserRequestsToRegister.Add(userRequest);
+        return this;
+    }
+}

--- a/src/Chat/Moneo.Chat/CommandRegistration/CommandRegistrar.cs
+++ b/src/Chat/Moneo.Chat/CommandRegistration/CommandRegistrar.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+
+namespace Moneo.Chat.CommandRegistration;
+
+public static class CommandRegistrar
+{
+    public const string RegistrationMethodName = "Register";
+    
+    public static void RegisterCommands(
+        MoneoChatCommandConfiguration configuration,
+        CancellationToken cancellationToken = default)
+    {
+        var assemblies = configuration.ChatCommandAssemblies.Distinct().ToArray();
+
+        foreach (var assembly in assemblies)
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                if (!typeof(IUserRequest).IsAssignableFrom(type) || type.IsAbstract)
+                {
+                    continue;
+                }
+
+                var userCommandAttribute = type.GetCustomAttribute<UserCommandAttribute>();
+                if (userCommandAttribute == null)
+                {
+                    continue;
+                }
+
+                configuration.UserRequestsToRegister.Add(type);
+            }
+        }
+
+        foreach (var type in configuration.UserRequestsToRegister.Distinct())
+        {
+            var registerMethod = type.GetMethod(RegistrationMethodName, BindingFlags.Public | BindingFlags.Static);
+            registerMethod?.Invoke(null, null);
+        }
+    }
+}

--- a/src/Chat/Moneo.Chat/HelpResponseFactory.cs
+++ b/src/Chat/Moneo.Chat/HelpResponseFactory.cs
@@ -1,21 +1,38 @@
+using System.Text;
+
 namespace Moneo.Chat;
 
-public static partial class HelpResponseFactory
+public static class HelpResponseFactory
 {
-    private static readonly Dictionary<string, string> _lookup = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, string> HelpResponseLookup = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly List<string> CommandList = [];
+    
+    public static string GetDefaultHelpResponse()
+    {
+        var defaultHelpText = new StringBuilder();
+        defaultHelpText.AppendLine("Available Commands");
+        defaultHelpText.AppendLine("------------------");
+        defaultHelpText.AppendLine();
+        foreach (var command in CommandList)
+        {
+            defaultHelpText.AppendLine(command);
+        }
+        
+        return defaultHelpText.ToString();
+    }
+    
+    public static void RegisterCommand(string commandKey, string helpResponse)
+    {
+        if (!HelpResponseLookup.TryAdd(commandKey, helpResponse))
+        {
+            throw new InvalidOperationException($"Command '{commandKey}' is already registered.");
+        }
+        
+        CommandList.Add(commandKey);
+    }
 
     public static string? GetHelpResponse(string commandKey)
     {
-        if (_lookup.Count == 0)
-        {
-            InitializeLookup();
-        }
-
-        if (!_lookup.TryGetValue(commandKey, out var response))
-        {
-            return null;
-        }
-
-        return response;
+        return HelpResponseLookup.GetValueOrDefault(commandKey);
     }
 }

--- a/src/Chat/Moneo.Chat/UserRequestFactory.cs
+++ b/src/Chat/Moneo.Chat/UserRequestFactory.cs
@@ -1,37 +1,24 @@
 namespace Moneo.Chat;
 
-public static partial class UserRequestFactory
+public static class UserRequestFactory
 {
     private static readonly Dictionary<string, Func<long, string[], IUserRequest>> _lookup = new(StringComparer.OrdinalIgnoreCase);
+    
+    public static void RegisterCommand(string commandKey, Func<long, string[], IUserRequest> constructor)
+    {
+        _lookup.TryAdd(commandKey, constructor);
+    }
 
     public static IUserRequest? GetUserRequest(CommandContext context)
     {
-        if (_lookup.Count == 0)
-        {
-            InitializeLookup();
-        }
-
-        if (!_lookup.TryGetValue(context.CommandKey, out var constructor))
-        {
-            return null;
-        }
-
-        return constructor.Invoke(context.ConversationId, context.Args);
+        return !_lookup.TryGetValue(context.CommandKey, out var constructor)
+            ? null
+            : constructor.Invoke(context.ConversationId, context.Args);
     }
 
     public static string? GetPotentialUserCommand(string key)
     {
-        if (_lookup.Count == 0)
-        {
-            InitializeLookup();
-        }
-
         var possibleCommand = "/" + key;
-        if (!_lookup.TryGetValue(possibleCommand, out _))
-        {
-            return null;
-        }
-
-        return possibleCommand;
+        return !_lookup.TryGetValue(possibleCommand, out _) ? null : possibleCommand;
     }
 }

--- a/src/Chat/Moneo.Chat/WorkflowManagerBase.cs
+++ b/src/Chat/Moneo.Chat/WorkflowManagerBase.cs
@@ -1,14 +1,22 @@
 ﻿using MediatR;
+using Moneo.Chat.Commands;
 
-namespace Moneo.Chat
+namespace Moneo.Chat;
+
+public interface IWorkflowManagerWithContinuation
 {
-    public abstract class WorkflowManagerBase
-    {
-        protected readonly IMediator Mediator;
+    Task<MoneoCommandResult> ContinueWorkflowAsync(
+        long chatId, 
+        string userInput, 
+        CancellationToken cancellationToken = default);
+}
 
-        protected WorkflowManagerBase(IMediator mediator)
-        {
-            Mediator = mediator;
-        }
+public abstract class WorkflowManagerBase
+{
+    protected readonly IMediator Mediator;
+
+    protected WorkflowManagerBase(IMediator mediator)
+    {
+        Mediator = mediator;
     }
 }

--- a/src/Chat/Moneo.Chat/Workflows/Help/HelpRequestHandler.cs
+++ b/src/Chat/Moneo.Chat/Workflows/Help/HelpRequestHandler.cs
@@ -5,24 +5,24 @@ namespace Moneo.Chat.Workflows.Chitchat;
 
 internal partial class HelpRequestHandler : IRequestHandler<HelpRequest, MoneoCommandResult>
 {
-    public async Task<MoneoCommandResult> Handle(HelpRequest request, CancellationToken cancellationToken)
+    public Task<MoneoCommandResult> Handle(HelpRequest request, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(request.UserText))
         {
-            return new MoneoCommandResult()
+            return Task.FromResult(new MoneoCommandResult()
             {
                 ResponseType = ResponseType.Text,
                 Type = ResultType.WorkflowCompleted,
-                UserMessageText = HelpResponseFactory.DefaultHelpResponse
-            };
+                UserMessageText = HelpResponseFactory.GetDefaultHelpResponse()
+            });
         }
 
         var responseText = HelpResponseFactory.GetHelpResponse(request.UserText.Replace("/", ""));
-        return new MoneoCommandResult()
+        return Task.FromResult(new MoneoCommandResult()
         {
             ResponseType = ResponseType.Text,
             Type = ResultType.WorkflowCompleted,
-            UserMessageText = responseText ?? HelpResponseFactory.DefaultHelpResponse
-        };
+            UserMessageText = responseText ?? HelpResponseFactory.GetDefaultHelpResponse()
+        });
     }
 }

--- a/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
+++ b/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
@@ -16,4 +16,19 @@
       <ProjectReference Include="..\..\TaskManagement\Moneo.TaskManagement.Contracts\Moneo.TaskManagement.Contracts.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <None Remove="appsettings.local.json" />
+      <Content Include="appsettings.local.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <None Remove="appsettings.json" />
+      <Content Include="appsettings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <None Remove="appsettings.Development.json" />
+      <Content Include="appsettings.Development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
 </Project>

--- a/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
+++ b/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <None Remove="appsettings.local.json" Condition="Exists('appsettings.Development.json')" />
-      <Content Include="appsettings.local.json">
+      <Content Include="appsettings.local.json" Condition="Exists('appsettings.Development.json')">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
       <None Remove="appsettings.json" />

--- a/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
+++ b/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
@@ -17,18 +17,16 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="appsettings.local.json" Condition="Exists('appsettings.Development.json')" />
-      <Content Include="appsettings.local.json" Condition="Exists('appsettings.Development.json')">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="appsettings.json" />
-      <Content Include="appsettings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <None Remove="appsettings.Development.json" />
-      <Content Include="appsettings.Development.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
+        <Content Include="appsettings.local.json" Condition="Exists('appsettings.local.json')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="appsettings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="appsettings.Development.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
+
 
 </Project>

--- a/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
+++ b/src/Hosts/Moneo.Hosts.Telegram.Console/Moneo.Hosts.Telegram.Console.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Remove="appsettings.local.json" />
+      <None Remove="appsettings.local.json" Condition="Exists('appsettings.Development.json')" />
       <Content Include="appsettings.local.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>


### PR DESCRIPTION
Changed the way the usercommand codegen works and how commands are registered and then located. This should allow for the task management commands to be pushed out of the Moneo.Chat assembly and also enable the addition of new commands from external libraries. Maybe this can all get put into a nuget package at that point (at least Moneo.Chat and the codegen library)